### PR TITLE
Modified bb_a21.c

### DIFF
--- a/DRIVER/COM/bb_a21.c
+++ b/DRIVER/COM/bb_a21.c
@@ -526,9 +526,7 @@ static int32 A21_BrdInfo(
 			/* supported */
 			case BBIS_FUNC_IRQENABLE:
 			case BBIS_FUNC_IRQSRVINIT:
-#if defined(A21_USE_MSI)
 			case BBIS_FUNC_IRQSRVEXIT:
-#endif
 				*used = TRUE;
 				break;
 			/* unsupported */


### PR DESCRIPTION
When used with M-Modules generating interrupts, the operating system didn't get an end of interrupt when processed.
Removed conditional compilation of case BBIS_FUNC_IRQSRVEXIT so the interrupt could be ended correctly.