### PR TITLE
Bugfix in bb_a21.c

### DIFF
--- a/DRIVER/COM/bb_a21.c
+++ b/DRIVER/COM/bb_a21.c
@@ -404,7 +404,7 @@ static int32 A21_BrdInit(
 	DBGWRT_1((DBH, "BB - %s_BrdInit\n",BBNAME));
 
 	for( mSlot=0; mSlot < A21_NBR_OF_MMODS; mSlot++ ){
-		MWRITE_D8( h->mmod[mSlot].vCtrlBase, 0, A21_MMOD_CTRL_TOUT | A21_MMOD_CTRL_IRQ );
+		MSETMASK_D8( h->mmod[mSlot].vCtrlBase, 0, A21_MMOD_CTRL_TOUT | A21_MMOD_CTRL_IRQ );
 	}
 
 	return 0;
@@ -430,7 +430,7 @@ static int32 A21_BrdExit(
 
 	for( mSlot=0; mSlot<A21_NBR_OF_MMODS; mSlot++ ){
 		/* Timeout and IRQ pending bit are cleared by writing '1' */
-		MWRITE_D8( h->mmod[mSlot].vCtrlBase, 0, A21_MMOD_CTRL_TOUT | A21_MMOD_CTRL_IRQ );
+		MSETMASK_D8( h->mmod[mSlot].vCtrlBase, 0, A21_MMOD_CTRL_TOUT | A21_MMOD_CTRL_IRQ );
 	}
 
     return 0;


### PR DESCRIPTION
When used with several M-Modules, each time a M_open()/M_close() is made on any device on one of the 3 slots of the A21B, the IRQ enable bit was cleared for all slots when A21_BrdInit()/A21_BrdExit() were called.
Change MWRITE_D8 to MSETMASK_D8 to do not overwrite the IRQ Enable bit.