### PR TITLE
update a21_cfginfo() in bb_a21.c

### DIFF
--- a/DRIVER/COM/bb_a21.c
+++ b/DRIVER/COM/bb_a21.c
@@ -721,19 +721,19 @@ static int32 A21_CfgInfo(
 			return status;
 		}
 		break;
+	}
+			
+	/* pci domain number */
+	case BBIS_CFGINFO_PCI_DOMAIN:
+	{
+		u_int32 *pciDomainNbr = va_arg( argptr, u_int32* );
+		u_int32 mSlot      = va_arg( argptr, u_int32 );
 
-        /* pci domain number */
-		case BBIS_CFGINFO_PCI_DOMAIN:
-		{
-			u_int32 *pciDomainNbr = va_arg( argptr, u_int32* );
-			u_int32 mSlot      = va_arg( argptr, u_int32 );
-
-			if ( G_slotCfg[CFIDX(mSlot)].pciDevNbr >= 0 )
-				*pciDomainNbr = G_slotCfg[CFIDX(mSlot)].pciDomainNbr;
-			else
-				*pciDomainNbr = A21_MMOD_BRIDGE_DOMAIN_NO;
-			mSlot = mSlot; /* dummy access to avoid compiler warning */
-		}
+		if ( G_slotCfg[CFIDX(mSlot)].pciDevNbr >= 0 )
+			*pciDomainNbr = G_slotCfg[CFIDX(mSlot)].pciDomainNbr;
+		else
+			*pciDomainNbr = A21_MMOD_BRIDGE_DOMAIN_NO;
+		mSlot = mSlot; /* dummy access to avoid compiler warning */
 		break;
 	}
 


### PR DESCRIPTION
Correct potential bug when requiring the PCI domain in a21_cfginfo().
The case BBIS_CFGINFO_PCI_DOMAIN was nested in case BBIS_CFGINFO_IRQ.